### PR TITLE
Use php binary from environment settings instead of hardcoded one

### DIFF
--- a/bin/tonic-php-cs-fixer
+++ b/bin/tonic-php-cs-fixer
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if (file_exists(sprintf('%s/../../../autoload.php', __DIR__))) {


### PR DESCRIPTION
/usr/bin/php causes conflicts in environments where php is locally built or installed via hombrew
