### PR TITLE
Fixing the version for php-cs-fixer(1.11.8).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "fabpot/php-cs-fixer": "1.11.*",
+        "fabpot/php-cs-fixer": "1.11.8",
         "squizlabs/php_codesniffer": "2.5.*",
         "m6web/symfony2-coding-standard": "3.1.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bd9c03ebba717edb2e88720657c1acb9",
-    "content-hash": "76063cec72556074163fee00725097ce",
+    "hash": "172cad35719083cddfaff80ef6dd558d",
+    "content-hash": "fcb2e3f2dcb252eb3130318131651a35",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
-            "version": "v1.11.1",
+            "version": "v1.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "2c9f8298181f059c5077abda78019b9a0c9a7cc0"
+                "reference": "117137e9970054d022b7656209f094dab852b90c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/2c9f8298181f059c5077abda78019b9a0c9a7cc0",
-                "reference": "2c9f8298181f059c5077abda78019b9a0c9a7cc0",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/117137e9970054d022b7656209f094dab852b90c",
+                "reference": "117137e9970054d022b7656209f094dab852b90c",
                 "shasum": ""
             },
             "require": {
@@ -32,8 +32,12 @@
                 "symfony/process": "~2.3|~3.0",
                 "symfony/stopwatch": "~2.5|~3.0"
             },
+            "conflict": {
+                "hhvm": "<3.9"
+            },
             "require-dev": {
-                "satooshi/php-coveralls": "0.7.*@dev"
+                "phpunit/phpunit": "^4.5|^5",
+                "satooshi/php-coveralls": "^0.7.1"
             },
             "bin": [
                 "php-cs-fixer"
@@ -59,7 +63,8 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-01-20 19:00:28"
+            "abandoned": "friendsofphp/php-cs-fixer",
+            "time": "2016-08-16 23:31:05"
         },
         {
             "name": "m6web/symfony2-coding-standard",


### PR DESCRIPTION
For version before 1.11.2 rules for phpdoc in begin file was
``` php
<?php
/**
 *   Some comment 
 */
namespace SomeClass
```
For version after 1.11.2 rule is:

``` php
<?php
/**
 *   Some comment 
 */

namespace SomeClass
```

After comment we have extra space.